### PR TITLE
Change parameter names of timeout_setcb()

### DIFF
--- a/timeout.h
+++ b/timeout.h
@@ -68,10 +68,10 @@ struct timeout_cb {
         (flags)                    \
     }
 
-#define timeout_setcb(to, fn, arg)  \
+#define timeout_setcb(to, _fn, _arg)  \
     do {                            \
-        (to)->callback.fn = (fn);   \
-        (to)->callback.arg = (arg); \
+        (to)->callback.fn = (_fn);   \
+        (to)->callback.arg = (_arg); \
     } while (0)
 
 struct timeout {


### PR DESCRIPTION
Because the parameter names are the same as
fields in `struct timeout_cb`, error will happen
when expending the macro.